### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/docs-md/ChangeLog.md
+++ b/docs-md/ChangeLog.md
@@ -22,7 +22,7 @@
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
-#Change log#
+# Change log #
 
 `React-metaform` uses **SemVer 2.0**. Given a version number MAJOR.MINOR.PATCH, increment the:
 
@@ -32,74 +32,74 @@
  
 However, before the 1.0.0 release, I'm *not changing* the major version, even if the change breaks compatibility.
  
-##History##
+## History ##
 
-###0.9.9 (Nov 20, 2015)
+### 0.9.9 (Nov 20, 2015)
 
  - Updates React, React-Router and many other packages
  - Fixes all warnings
 
-###0.8.2 (Oct 25, 2015)
+### 0.8.2 (Oct 25, 2015)
 
  - Fixes the lib build to include the LESS folder in the resuling lib folder.
 
-###0.8.1 (Oct 25, 2015)
+### 0.8.1 (Oct 25, 2015)
 
  - Fixes the lib build from the previous version.
 
-###0.8.0 (Oct 19, 2015) [broken, skip this version]
+### 0.8.0 (Oct 19, 2015) [broken, skip this version]
 
  - ArrayGridContainer styles are now better
  - The Lookup field is now reacting correctly to the required metadata
  - SelectiveMetaFormGroup is now automatically adding fields that are invalid and fields that have value
  - ArrayContainer and the ArrayGridContainer now show an Alert when they are empty
 
-###0.7.0 (Oct 11, 2015)
+### 0.7.0 (Oct 11, 2015)
 
  - Layouts are now optional
 
-###0.6.0 (Oct 11, 2015)
+### 0.6.0 (Oct 11, 2015)
 
  - Introducing the ArrayGridContainer component
 
-###0.5.0 (Oct 7, 2015)
+### 0.5.0 (Oct 7, 2015)
 
  - Removing the ability to collapse groups. It just did not work
 
-###0.4.0 (Oct 7, 2015)
+### 0.4.0 (Oct 7, 2015)
 
  - Group components now have the ability to collapse
  - Components are now represented by CamelCase in the ComponentFactory
  - Added styles for the group components
 
-###0.3.2 (Oct 4, 2015)
+### 0.3.2 (Oct 4, 2015)
 
  - Bug fixes: The ArrayContainer and the EntityContainer were not using the ComponentBuilder to resolve the group component.
  - There was a bug in the MetadataProvider that was making it impossible to create layout groups inside inner entities.
 
-###0.3.1 (Oct 3, 2015)
+### 0.3.1 (Oct 3, 2015)
 
  - Bug fixes. The ArrayContainer and the EntityContainer were not working since version 0.3.0.
 
-###0.3.0 (Oct 2, 2015)
+### 0.3.0 (Oct 2, 2015)
 
  - Now it's possible to define components for the groups (before it was only for fields).
  - Resulting bundle is now smaller. The CodeEditor has been moved out to the demo.
 
-###0.2.11 (Sep 30, 2015)
+### 0.2.11 (Sep 30, 2015)
 
  - Removing the LiveSchemaEditor from the library (it's now part of the demo).
  - The LiveSchemaEditor version is now dynamic.
 
-###0.2.10 (Sep 30, 2015)
+### 0.2.10 (Sep 30, 2015)
 
  - Improving the MetaForm resilience to schema errors.
 
-###0.2.9 (Sep 29, 2015)
+### 0.2.9 (Sep 29, 2015)
 
  - Adding support for text-expressions.
 
 
-###0.2.8 (Sep 26, 2015)
+### 0.2.8 (Sep 26, 2015)
 
  - First public release.

--- a/docs-md/Documentation.md
+++ b/docs-md/Documentation.md
@@ -23,13 +23,13 @@
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
-#React-metaform#
+# React-metaform #
 
 > Be patient. This documentation is still under construction. Pull-requests are welcome.
 
 For an introduction to the library, as well as instructions on how to install, run and build it, please refer to the [README.md](https://github.com/gearz-lab/react-metaform/blob/master/readme.md).
 
-##Metadata##
+## Metadata ##
 
 Metadata is the single most important thing to understand in order to work with `react-metaform`. Basically, you pass a
 `schema` to the `MetaForm` component and it renders itself. You can find examples of valid schema [here](https://github.com/gearz-lab/react-metaform/tree/master/demo/components/liveSchemaEditorPresets).
@@ -44,7 +44,7 @@ These are the most important things you should know about Metadata:
  - Each `Field` metadata can be either a literal or a function. When it's a function, it's evaluated automatically every time the
  form changes.
 
-###Schema###
+### Schema ###
 
 The root of all metadata. It may represent your entire application schema or just a subset of it. If you choose to pass only
 a subset to the `MetaForm`, make sure it contains all the referenced `entities`.
@@ -53,7 +53,7 @@ Metadata | Description
 --- | ---
 entities | An array of `entity`.
 
-###Entity###
+### Entity ###
 
 Represents an `entity`. 
 
@@ -63,7 +63,7 @@ name | The `entity` name
 fields | An array or `field`.
 layouts | An array or `layout`.
 
-###Layout###
+### Layout ###
 
 Represents a visualization of an `entity`. Examples of layouts would be `edit` and `details`.  Every `entity` field that
  should be displayed in a `layout`  should be declared both in the `entity.fields` and in the `layout.fields` or `layout.someGroup.fields`.
@@ -77,7 +77,7 @@ fields | An array of `field`. These `fields` are merged with the fields from the
 merged based on the `name` metadata.
 groups | (optional) An array of `group`.
 
-###Group###
+### Group ###
 
 Represents a group in the `layout`. Groups exist just so the `layouts` are flexible and customizable.
 
@@ -88,7 +88,7 @@ fields | An array of `field`. These `fields` are merged with the fields from the
 merged based on the `name` metadata.
 groups | (optional) An array of `group`.
 
-###Field###
+### Field ###
 
 Represents a `field`. `Fields` can exist in `entities`, `layouts` or `groups`. `Field` metadata are passed to the component as `props`.
  
@@ -115,7 +115,7 @@ type | The `field` type. This is the default way to determine which component sh
 
 Other `field` metadata will depend on the component.
  
-####Common####
+#### Common ####
 
 Metadata that is common to most of the components.
 
@@ -131,7 +131,7 @@ readOnly | Whether or not the component should be in read-only state.
 onChange | Handles the component change. The callback function receives 2 parameters: The field name and an event which value is the new value for the component. To get the new value you need to access `e.value`.
 help | Additional help so the end-user knows what the field is about.
 
-####Input####
+#### Input ####
 
 Metadata for the `Input` component.
 
@@ -148,11 +148,11 @@ hasFeedbackIcon | If feedback should be displayed, `hasFeedbackIcon` determines 
 groupClassName | The CSS class that should be added to the Bootstrap field group.
 labelClassName | The CSS class that should be added to the Bootstrap field label.
 
-####CheckBox####
+#### CheckBox ####
 
 Metadata for the CheckBox component. The CheckBox doesn't have any specific metadata.
 
-####Select and Lookup####
+#### Select and Lookup ####
 
 Metadata for the Select and Lookup components.
 
@@ -160,20 +160,20 @@ Metadata | Description
 --- | ---
 options | The options to display. Options are an array of objects with two properties: **value**: The actual value that is stored in the model. **text**: What is displayed to the user
 
-##Lib##
+## Lib ##
 
-###Component factories###
+### Component factories ###
 
 Component factories are how `react-metaform` knows which component to render for a particular field or group metadata.
 
-####ComponentFactory ([source](https://github.com/gearz-lab/react-metaform/blob/master/src/ComponentFactory.js))####
+#### ComponentFactory ([source](https://github.com/gearz-lab/react-metaform/blob/master/src/ComponentFactory.js)) ####
 
 This a *clean* factory. In order to use it, `import` it, register all your components and then pass it to the `componentFactory`
 prop of the `MetaForm`.
 
     import ComponentFactory from 'react-metaform/lib/ComponentFactory';
 
-####DefaultComponentFactory ([source](https://github.com/gearz-lab/react-metaform/blob/master/src/DefaultComponentFactory.js))####
+#### DefaultComponentFactory ([source](https://github.com/gearz-lab/react-metaform/blob/master/src/DefaultComponentFactory.js)) ####
 
 This is a pre-populated factory, the same used in the [demo](http://gearz-lab.github.io/react-metaform/demo.html).
 In order to use it, `import` it and just pass it to the `componentFactory` prop of the `MetaForm`.
@@ -182,9 +182,9 @@ In order to use it, `import` it and just pass it to the `componentFactory` prop 
     
 The `DefaultComponentFactory` relies on [these third-party components](#third-party).
 
-##Components##
+## Components ##
 
-###MetaForm###
+### MetaForm ###
 
 A form component that renders itself based on metadata
 
@@ -201,7 +201,7 @@ onModelChange | Function called whenever the model changes
 onSave | Function called when the Save button is clicked
 onCancel | Function called when the Cancel button is clicked
 
-###Third party###
+### Third party ###
 
 The `DefaultComponentFactory` relies on third-party components. Here's the list:
 

--- a/readme.md
+++ b/readme.md
@@ -40,7 +40,7 @@ Install:
 Using
 ---
 
-####MetaForm ([source](https://github.com/gearz-lab/react-metaform/blob/master/src/MetaForm.js))####
+#### MetaForm ([source](https://github.com/gearz-lab/react-metaform/blob/master/src/MetaForm.js)) ####
 
 The main React component.
 
@@ -51,14 +51,14 @@ The `MetaForm` props are listed [here](https://github.com/gearz-lab/react-metafo
 Additionally, you need a `ComponentFactory`. The `ComponentFactory` is responsible for determining which React
 component to use for a given field metadata. `React-metaform` comes with 2 `ComponentFactories`:
 
-####ComponentFactory ([source](https://github.com/gearz-lab/react-metaform/blob/master/src/ComponentFactory.js))####
+#### ComponentFactory ([source](https://github.com/gearz-lab/react-metaform/blob/master/src/ComponentFactory.js)) ####
 
 This a *clean* factory. In order to use it, `import` it, register all your components and then pass it to the `componentFactory`
 prop of the `MetaForm`.
 
     import ComponentFactory from 'react-metaform/lib/ComponentFactory';
     
-####DefaultComponentFactory ([source](https://github.com/gearz-lab/react-metaform/blob/master/src/DefaultComponentFactory.js))####
+#### DefaultComponentFactory ([source](https://github.com/gearz-lab/react-metaform/blob/master/src/DefaultComponentFactory.js)) ####
 
 This is a pre-populated factory, the same used in the [demo](http://gearz-lab.github.io/react-metaform/demo.html).
 In order to use it, `import` it and just pass it to the `componentFactory` prop of the `MetaForm`.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
